### PR TITLE
Fix missing validator for chat model field

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -3,6 +3,8 @@ from wtforms import SelectField, TextAreaField, SubmitField
 from wtforms.validators import DataRequired
 
 class ChatForm(FlaskForm):
-    model   = SelectField("LLM")
+    # require the user to choose a model so the route logic doesn't
+    # attempt to split an empty value when no models are enabled
+    model   = SelectField("LLM", validators=[DataRequired()])
     prompt  = TextAreaField("Prompt", validators=[DataRequired()])
     submit  = SubmitField("Send")


### PR DESCRIPTION
## Summary
- prevent crash when no model is selected by requiring a choice in `ChatForm`

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_6876819695ac8323a10811d7f14da042